### PR TITLE
Outputting a more descriptive message when struct arguments don't match.

### DIFF
--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -39,12 +39,6 @@ func ObjectsAreEqual(expected, actual interface{}) bool {
 		return true
 	}
 
-	// This was removed in https://github.com/stretchr/testify/commit/e22aedd37671fb115be6c0c25129c405cb575cfd which
-	// breaks nearly all of our tests that test interface values
-	if fmt.Sprintf("%#v", expected) == fmt.Sprintf("%#v", actual) {
-		return true
-	}
-
 	return false
 
 }
@@ -621,6 +615,25 @@ func Panics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 
 	if funcDidPanic, panicValue := didPanic(f); !funcDidPanic {
 		return Fail(t, fmt.Sprintf("func %#v should panic\n\r\tPanic value:\t%v", f, panicValue), msgAndArgs...)
+	}
+
+	return true
+}
+
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//   assert.Panics(t, func(){
+//     GoCrazy()
+//   }, "Calling GoCrazy() should panic")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func PanicsWithMessage(t TestingT, f PanicTestFunc, expectedMessage interface{}, msgAndArgs ...interface{}) bool {
+
+	funcDidPanic, panicValue := didPanic(f)
+	if !funcDidPanic {
+		return Fail(t, fmt.Sprintf("func %#v should panic\n\r\tPanic value:\t%v", f, panicValue), msgAndArgs...)
+	} else {
+		Equal(t, expectedMessage, panicValue)
 	}
 
 	return true


### PR DESCRIPTION
Outputting a more descriptive message when struct arguments don't match on an unexpected call.
