### PR TITLE
Outputting a more descriptive message when struct arguments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ go:
   - 1.3
   - tip
 
+before_install:
+  - mv $HOME/gopath/src/github.com/C2FO $HOME/gopath/src/github.com/c2fo
+  - export PATH=$PATH:$HOME/gopath/bin
+
 script:
   - go test -v ./...
 

--- a/assert/assertions.go
+++ b/assert/assertions.go
@@ -626,6 +626,25 @@ func Panics(t TestingT, f PanicTestFunc, msgAndArgs ...interface{}) bool {
 	return true
 }
 
+// Panics asserts that the code inside the specified PanicTestFunc panics.
+//
+//   assert.Panics(t, func(){
+//     GoCrazy()
+//   }, "Calling GoCrazy() should panic")
+//
+// Returns whether the assertion was successful (true) or not (false).
+func PanicsWithMessage(t TestingT, f PanicTestFunc, expectedMessage interface{}, msgAndArgs ...interface{}) bool {
+
+	funcDidPanic, panicValue := didPanic(f)
+	if !funcDidPanic {
+		return Fail(t, fmt.Sprintf("func %#v should panic\n\r\tPanic value:\t%v", f, panicValue), msgAndArgs...)
+	} else {
+		Equal(t, expectedMessage, panicValue)
+	}
+
+	return true
+}
+
 // NotPanics asserts that the code inside the specified PanicTestFunc does NOT panic.
 //
 //   assert.NotPanics(t, func(){

--- a/doc.go
+++ b/doc.go
@@ -14,9 +14,9 @@ package testify
 // blank imports help docs.
 import (
 	// assert package
-	_ "github.com/stretchr/testify/assert"
+	_ "github.com/c2fo/testify/assert"
 	// http package
-	_ "github.com/stretchr/testify/http"
+	_ "github.com/c2fo/testify/http"
 	// mock package
-	_ "github.com/stretchr/testify/mock"
+	_ "github.com/c2fo/testify/mock"
 )

--- a/http/test_round_tripper.go
+++ b/http/test_round_tripper.go
@@ -1,7 +1,7 @@
 package http
 
 import (
-	"github.com/stretchr/testify/mock"
+	"github.com/c2fo/testify/mock"
 	"net/http"
 )
 

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"runtime"
@@ -9,7 +10,12 @@ import (
 	"time"
 
 	"github.com/stretchr/objx"
-	"github.com/stretchr/testify/assert"
+	"github.com/c2fo/testify/assert"
+)
+
+const (
+	unexpectedMethodCall        = "\nassert: mock: I don't know what to return because the method call was unexpected.\n\tEither do Mock.On(\"%s\").Return(...) first, or remove the %s() call.\n\tThis method was unexpected:\n\t\t%s\n\tat: %s"
+	unexpectedMethodCallClosest = "\n\nmock: Unexpected Method Call\n-----------------------------\n\n%s\n\nThe closest call I have is: \n\n%s\n"
 )
 
 // TestingT is an interface wrapper around *testing.T
@@ -228,7 +234,11 @@ func callString(method string, arguments Arguments, includeArgumentValues bool) 
 	if includeArgumentValues {
 		var argVals []string
 		for argIndex, arg := range arguments {
-			argVals = append(argVals, fmt.Sprintf("%d: %v", argIndex, arg))
+			objectString, err := json.Marshal(arg)
+			if err != nil {
+				objectString = []byte(err.Error())
+			}
+			argVals = append(argVals, fmt.Sprintf("%d: %s", argIndex, string(objectString)))
 		}
 		argValsString = fmt.Sprintf("\n\t\t%s", strings.Join(argVals, "\n\t\t"))
 	}
@@ -263,9 +273,9 @@ func (m *Mock) Called(arguments ...interface{}) Arguments {
 		closestFound, closestCall := m.findClosestCall(functionName, arguments...)
 
 		if closestFound {
-			panic(fmt.Sprintf("\n\nmock: Unexpected Method Call\n-----------------------------\n\n%s\n\nThe closest call I have is: \n\n%s\n", callString(functionName, arguments, true), callString(functionName, closestCall.Arguments, true)))
+			panic(fmt.Sprintf(unexpectedMethodCallClosest, callString(functionName, arguments, true), callString(functionName, closestCall.Arguments, true)))
 		} else {
-			panic(fmt.Sprintf("\nassert: mock: I don't know what to return because the method call was unexpected.\n\tEither do Mock.On(\"%s\").Return(...) first, or remove the %s() call.\n\tThis method was unexpected:\n\t\t%s\n\tat: %s", functionName, functionName, callString(functionName, arguments, true), assert.CallerInfo()))
+			panic(fmt.Sprintf(unexpectedMethodCall, functionName, functionName, callString(functionName, arguments, true), assert.CallerInfo()))
 		}
 	} else {
 		m.mutex.Lock()

--- a/mock/mock_test.go
+++ b/mock/mock_test.go
@@ -2,7 +2,8 @@ package mock
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
+	"fmt"
+	"github.com/c2fo/testify/assert"
 	"testing"
 	"time"
 )
@@ -10,6 +11,16 @@ import (
 /*
 	Test objects
 */
+
+type ExampleEmbeddedStruct struct {
+	TestVal2 int
+	TestVal3 int
+}
+
+type ExampleTestStruct struct {
+	ExampleEmbeddedStruct
+	TestVal1 int
+}
 
 // ExampleInterface represents an example interface.
 type ExampleInterface interface {
@@ -58,6 +69,11 @@ type ExampleFuncType func(string) error
 
 func (i *TestExampleImplementation) TheExampleMethodFuncType(fn ExampleFuncType) error {
 	args := i.Called(fn)
+	return args.Error(0)
+}
+
+func (i *TestExampleImplementation) TheExampleStructMethod(exampleTestStruct *ExampleTestStruct) error {
+	args := i.Called(exampleTestStruct)
 	return args.Error(0)
 }
 
@@ -559,9 +575,36 @@ func Test_Mock_Called_For_SetTime_Expectation(t *testing.T) {
 	mockedService.TheExampleMethod(1, 2, 3)
 	mockedService.TheExampleMethod(1, 2, 3)
 	mockedService.TheExampleMethod(1, 2, 3)
-	assert.Panics(t, func() {
+	assert.PanicsWithMessage(t, func() {
 		mockedService.TheExampleMethod(1, 2, 3)
-	})
+	}, fmt.Sprintf(unexpectedMethodCallClosest, "TheExampleMethod(int,int,int)\n\t\t0: 1\n\t\t1: 2\n\t\t2: 3", "TheExampleMethod(int,int,int)\n\t\t0: 1\n\t\t1: 2\n\t\t2: 3"))
+
+}
+
+func Test_Mock_Called_For_EmbeddedStruct_Expectation(t *testing.T) {
+
+	var mockedService *TestExampleImplementation = new(TestExampleImplementation)
+
+	exampleTestStruct := &ExampleTestStruct{
+		TestVal1: 1,
+		ExampleEmbeddedStruct: ExampleEmbeddedStruct{
+			TestVal2: 2,
+			TestVal3: 3,
+		},
+	}
+
+	mockedService.On("TheExampleStructMethod", exampleTestStruct).Return(nil)
+
+	assert.PanicsWithMessage(t, func() {
+		exampleTestStructBad := &ExampleTestStruct{
+			TestVal1: 4,
+			ExampleEmbeddedStruct: ExampleEmbeddedStruct{
+				TestVal2: 5,
+				TestVal3: 6,
+			},
+		}
+		mockedService.TheExampleStructMethod(exampleTestStructBad)
+	}, fmt.Sprintf(unexpectedMethodCallClosest, "TheExampleStructMethod(*mock.ExampleTestStruct)\n\t\t0: {\"TestVal2\":5,\"TestVal3\":6,\"TestVal1\":4}", "TheExampleStructMethod(*mock.ExampleTestStruct)\n\t\t0: {\"TestVal2\":2,\"TestVal3\":3,\"TestVal1\":1}"))
 
 }
 

--- a/package_test.go
+++ b/package_test.go
@@ -1,7 +1,7 @@
 package testify
 
 import (
-	"github.com/stretchr/testify/assert"
+	"github.com/c2fo/testify/assert"
 	"testing"
 )
 

--- a/require/forward_requirements.go
+++ b/require/forward_requirements.go
@@ -3,7 +3,7 @@ package require
 import (
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/c2fo/testify/assert"
 )
 
 type Assertions struct {

--- a/require/requirements.go
+++ b/require/requirements.go
@@ -3,7 +3,7 @@ package require
 import (
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/c2fo/testify/assert"
 )
 
 type TestingT interface {

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -8,8 +8,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/c2fo/testify/assert"
+	"github.com/c2fo/testify/require"
 )
 
 var matchMethod = flag.String("m", "", "regular expression to select tests of the suite to run")

--- a/suite/suite_test.go
+++ b/suite/suite_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/c2fo/testify/assert"
 )
 
 // This suite is intended to store values to make sure that only


### PR DESCRIPTION
Outputting a more descriptive message when struct arguments don't match on an unexpected call.
- [ ] @TechnotronicOz 
- [ ] @doug-martin 
